### PR TITLE
Add log adapter

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -149,6 +149,37 @@ like this.
         logger.info("Logging from task!")
 
 
+Adapt object to log record fields
+---------------------------------
+
+It can be cumbersome and error-prone to repeat every where in the codebase the
+association *field name*, *object property*. *pylogctx* allow a simple way to
+register adapter to class.
+
+.. code-block::
+
+    import uuid
+
+    from pylogctx import log_adapter
+    from django.http.request import HttpRequest
+
+    @log_adapter(HttpRequest)
+    def adapt_django_requests(request):
+        return {
+            djangoRequestId: str(uuid.uuid4()),
+        }
+
+
+Triggering the adapt logic is as easy as pushing the objects right into the
+context.
+
+.. code-block::
+
+    from pylogctx import log_context
+
+    log_context.update(request)
+
+
 Contributors
 ============
 

--- a/src/pylogctx/__init__.py
+++ b/src/pylogctx/__init__.py
@@ -2,10 +2,12 @@ from .core import (
     AddContextFilter,
     AddContextFormatter,
     context,
+    log_adapter,
 )
 
 __all__ = [
     'AddContextFilter',
     'AddContextFormatter',
     'context',
+    'log_adapter',
 ]


### PR DESCRIPTION
Hi,

Another nice addition is to allow generic log adapter pattern. This make it easy to log objects such as requests, model, or any thirdparty object.

In our code we have such listing:

```python

document = Document.get_or_404(...)
log_context.update(document)
# ... all logs will now contains all fields related to the document
```