### PR TITLE
Outer middlewares

### DIFF
--- a/src/pylogctx/__init__.py
+++ b/src/pylogctx/__init__.py
@@ -1,4 +1,5 @@
 from .core import (
+    AdapterNotFound,
     AddContextFilter,
     AddContextFormatter,
     LazyAccessor,
@@ -7,6 +8,7 @@ from .core import (
 )
 
 __all__ = [
+    'AdapterNotFound',
     'AddContextFilter',
     'AddContextFormatter',
     'LazyAccessor',

--- a/src/pylogctx/celery.py
+++ b/src/pylogctx/celery.py
@@ -1,18 +1,25 @@
 from __future__ import absolute_import
 
+import logging
+
 from celery.app import current_task
 from celery.app.task import Task
 
 from .core import context
 
 
+logger = logging.getLogger(__name__)
+
+
 class LoggingTask(Task):
     def __call__(self, *args, **kwargs):
         task = current_task()
-        context.update(
-            celeryTask=task.name,
-            celeryTaskId=task.request.id,
-        )
+
+        try:
+            context.update(task)
+        except Exception as e:
+            logger.debug('Failed to push task to log context: %r', e)
+
         try:
             return super(LoggingTask, self).__call__(*args, **kwargs)
         finally:

--- a/src/pylogctx/core.py
+++ b/src/pylogctx/core.py
@@ -109,6 +109,10 @@ class AddContextFormatter(logging.Formatter):
 _adapter_mapping = {}
 
 
+class AdapterNotFound(Exception):
+    pass
+
+
 def log_adapter(class_):
     def decorator(callable_):
         _adapter_mapping[class_] = callable_
@@ -124,7 +128,7 @@ def adapt(object_):
         except KeyError:
             continue
     else:
-        raise Exception("Can't log object of type %r" % type(object_))
+        raise AdapterNotFound("Can't log object of type %r" % type(object_))
     return adapter(object_)
 
 

--- a/src/pylogctx/django.py
+++ b/src/pylogctx/django.py
@@ -4,19 +4,19 @@ import logging
 
 from django.conf import settings
 
-from pylogctx import context
+from pylogctx import context, AdapterNotFound
 
 
 logger = logging.getLogger(__name__)
 
 
-class ExtractRequestContextMiddleware(object):
+class OuterMiddleware(object):
     def process_request(self, request):
-        extractor = settings.PYLOGCTX_REQUEST_EXTRACTOR
+        context.clear()
         try:
-            context.update(**extractor(request))
-        except Exception:
-            logger.exception()
+            context.update(request)
+        except AdapterNotFound:
+            logger.info("Can't adapt %s for log.", request.__class__.__name__)
 
     def process_response(self, request, response):
         context.clear()
@@ -25,3 +25,13 @@ class ExtractRequestContextMiddleware(object):
     def process_exception(self, request, exception):
         context.clear()
         return None
+
+
+class ExtractRequestContextMiddleware(OuterMiddleware):
+    def process_request(self, request):
+        context.clear()
+        extractor = settings.PYLOGCTX_REQUEST_EXTRACTOR
+        try:
+            context.update(**extractor(request))
+        except Exception:
+            logger.exception()

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -44,17 +44,17 @@ def test_middleware_extraction_failed(request):
 
 
 @patch('pylogctx.django.settings', PYLOGCTX_REQUEST_EXTRACTOR=_extractor)
-def test_middleware_context_extracted(request, context):  # noqa
+def test_middleware_context_extracted(request, context):
     ExtractRequestContextMiddleware().process_request(request)
     fields = log_context.as_dict()
     assert 'rid' in fields
 
 
-def test_middleware_context_cleaned_on_response(context):  # noqa
+def test_middleware_context_cleaned_on_response(context):
     ExtractRequestContextMiddleware().process_response(None, None)
     assert not log_context.as_dict()
 
 
-def test_middleware_context_cleaned_on_exception(context):  # noqa
+def test_middleware_context_cleaned_on_exception(context):
     ExtractRequestContextMiddleware().process_exception(None, None)
     assert not log_context.as_dict()

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -18,7 +18,7 @@ def request():
 @pytest.yield_fixture
 def context():
     log_context.update(rid=42)
-    yield None
+    yield log_context
     try:
         del log_context._stack
     except AttributeError:
@@ -40,14 +40,14 @@ def test_middleware_no_extractor(request):
 
 @patch('pylogctx.django.settings',
        PYLOGCTX_REQUEST_EXTRACTOR=_failing_extractor)
-def test_middleware_extraction_failed(request):
+def test_middleware_extraction_failed(settings, request):
     with patch('pylogctx.django.logger') as m:
         ExtractRequestContextMiddleware().process_request(request)
-        assert m.method_calls == [call.exception()]
+        assert call.exception() in m.method_calls
 
 
 @patch('pylogctx.django.settings', PYLOGCTX_REQUEST_EXTRACTOR=_extractor)
-def test_middleware_context_extracted(request, context):
+def test_middleware_context_extracted(settings, request, context):
     ExtractRequestContextMiddleware().process_request(request)
     fields = log_context.as_dict()
     assert 'rid' in fields


### PR DESCRIPTION
Hi,

One more PR to fine tune the code. The base purpose is to provide an out of the box middleware for request that *just* clear the context and *if activated*, tries to push the request object itself.

I updated the task middleware to have the same behaviour.

That may sound redundant with the extractor logic. extractor is actually a specific case of adapter.

What do you think of this ?