### PR TITLE
Py3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: python
+python:
+- '3.5'
 install: pip install tox
 script: tox

--- a/setup.py
+++ b/setup.py
@@ -55,5 +55,6 @@ setup(
         'mock>=2.0.0',
         'pytest>=2.9.0',
         'celery',
+        'six'
     ],
 )

--- a/src/pylogctx/core.py
+++ b/src/pylogctx/core.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import itertools
 import logging
 import threading
@@ -106,10 +108,10 @@ class ExcInfoFilter(logging.Filter):
 class AddContextFormatter(logging.Formatter):
     def format(self, record):
         msg = super(AddContextFormatter, self).format(record)
-        context_str = u' '.join([
-            u'{}:{}'.format(k, v) for k, v in context.items()
+        context_str = ' '.join([
+            '{}:{}'.format(k, v) for k, v in context.items()
         ])
-        return u'{msg} {context}'.format(msg=msg, context=context_str)
+        return '{msg} {context}'.format(msg=msg, context=context_str)
 
 
 _adapter_mapping = {}

--- a/tests/test_celery.py
+++ b/tests/test_celery.py
@@ -1,6 +1,7 @@
 from celery import Celery
 from celery.app import current_task
 from celery.utils.log import get_task_logger
+from celery import VERSION
 
 from mock import patch
 
@@ -18,7 +19,10 @@ def test_task():
         return context.as_dict()
 
     result = my_task.apply()
-    result.maybe_reraise()
+    if VERSION.major < 4:
+        result.maybe_reraise()
+    else:
+        result.maybe_throw()
     fields = result.result
     assert 'taskField' in fields
     assert not context.as_dict()
@@ -56,7 +60,11 @@ def test_adapter():
         }
 
     result = my_task.apply()
-    result.maybe_reraise()
+    if VERSION.major < 4:
+        result.maybe_reraise()
+    else:
+        result.maybe_throw()
+
     fields = result.result
     assert 'celeryTask' in fields
     assert 'celeryTaskId' in fields

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py27
+envlist = lint,py27,py35
 
 [testenv]
 commands = python setup.py test


### PR DESCRIPTION
I've added support for python3.5. Also I've fixed problem with celery 4.0.x with missing `AsyncResult.maybe_reraise` method (it was necessary, otherwise tests were fails).
@bersace please take a look.